### PR TITLE
perf: Change buffer capacity

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,12 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/[Keep a Changelog], and this
 project adheres to https://semver.org/[Semantic Versioning].
 
+== {compare-url}/v0.1.1\...HEAD[Unreleased]
+
+=== Changed
+
+* Change the buffer capacity ({pull-request-url}/14[#14])
+
 == {compare-url}/v0.1.0\...v0.1.1[0.1.1] - 2025-03-11
 
 === Added

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,8 +12,11 @@ use crate::{
     rng::Rng,
 };
 
-// 2 KiB.
-const CHUNK_SIZE: usize = 1 << 11;
+// 8 KiB.
+const CHUNK_SIZE: usize = 1 << 13;
+
+// 1 MiB.
+const BUF_SIZE: usize = 1 << 20;
 
 /// Runs the program and returns the result.
 pub fn run() -> anyhow::Result<()> {
@@ -32,7 +35,7 @@ pub fn run() -> anyhow::Result<()> {
     };
 
     let stdout = io::stdout();
-    let mut writer = BufWriter::new(stdout.lock());
+    let mut writer = BufWriter::with_capacity(BUF_SIZE, stdout.lock());
 
     let mut remaining = opt
         .length
@@ -99,6 +102,11 @@ mod tests {
 
     #[test]
     fn chunk_size() {
-        assert_eq!(CHUNK_SIZE, 2048);
+        assert_eq!(CHUNK_SIZE, 8192);
+    }
+
+    #[test]
+    fn buf_size() {
+        assert_eq!(BUF_SIZE, 1_048_576);
     }
 }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Before change:

| Command                       |      Mean [s] | Min [s] | Max [s] | Relative |
| :---------------------------- | ------------: | ------: | ------: | -------: |
| `cargo run --release -- 4GiB` | 2.843 ± 0.018 |   2.823 |   2.887 |     1.00 |

After change:

| Command                       |      Mean [s] | Min [s] | Max [s] | Relative |
| :---------------------------- | ------------: | ------: | ------: | -------: |
| `cargo run --release -- 4GiB` | 2.035 ± 0.018 |   2.011 |   2.077 |     1.00 |

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/randgen/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/randgen/blob/develop/CODE_OF_CONDUCT.md
