### PR TITLE
perf: Change buffer capacity when output is small

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,12 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/[Keep a Changelog], and this
 project adheres to https://semver.org/[Semantic Versioning].
 
+== {compare-url}/v0.1.2\...HEAD[Unreleased]
+
+=== Changed
+
+* Change the buffer capacity when output is small ({pull-request-url}/17[#17])
+
 == {compare-url}/v0.1.1\...v0.1.2[0.1.2] - 2025-03-22
 
 === Changed


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
If the output length is smaller than `BUF_SIZE`, set the buffer capacity equal to the output length.

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/randgen/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/randgen/blob/develop/CODE_OF_CONDUCT.md
